### PR TITLE
feat: show more proper demo example and add more theme components

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ To test with other themes defined in `src/`, you need to change the following li
 
 If you make changes in files below `src/`, you will need to re-run the `yarn start` command to test in the demo webpage.
 
+### Updating Demo Page
+If you want to display a specific font family (e.g., 'Roboto Condensed') that is not installed in your computer, you may want to embed the font in the demo webpage. You can do this by adding a single line of code in `demo/index.html` (Refer to the current code):
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&display=swap" rel="stylesheet">
+```
+
+You can get this code, for example, in the Google Fonts website (https://fonts.google.com/specimen/Roboto+Condensed). Select "Light", "Regular", and "Bold" and the website will show you the source code like the above that you can use.
+
 ### Publish Package
 When you patch the version and push the code with tags, GitHub will do the job to publish the latest NPM package:
 

--- a/demo/example-1.js
+++ b/demo/example-1.js
@@ -1,0 +1,401 @@
+example1 = {
+    "title": "Gosling Theme",
+    "subtitle": "Using the gosling themes, you can easily apply styling to gosling visualizations",
+    "arrangement": "vertical",
+    "centerRadius": 0.6,
+    "spacing": 40,
+    "views": [
+        {
+            "arrangement": 'horizontal',
+            spacing: 80,
+            "views": [
+                {
+                    "spacing": 0.1,
+                    "static": true,
+                    "layout": "circular",
+                    "alignment": "stack",
+                    "tracks": [
+                        {
+                            "title": "Whole Genome",
+                            "alignment": "overlay",
+                            "tracks": [
+                                { "mark": "bar" },
+                                { "mark": "brush", "x": { "linkingId": "middle" } }
+                            ],
+                            "data": {
+                                "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+                                "type": "multivec",
+                                "row": "sample",
+                                "column": "position",
+                                "value": "peak",
+                                "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
+                            },
+                            "x": { "field": "start", "type": "genomic" },
+                            "xe": { "field": "end", "type": "genomic" },
+                            "y": { "field": "peak", "type": "quantitative" },
+                            // "row": {"field": "sample", "type": "nominal"},
+                            "color": { "field": "sample", "type": "nominal" },
+                            "width": 500,
+                            "height": 130
+                        },
+                        {
+                            "alignment": "overlay",
+                            "data": {
+                                "url": "https://raw.githubusercontent.com/vigsterkr/circos/master/data/5/segdup.txt",
+                                "type": "csv",
+                                "headerNames": ["id", "chr", "p1", "p2"],
+                                "chromosomePrefix": "hs",
+                                "chromosomeField": "chr",
+                                "genomicFields": ["p1", "p2"],
+                                "separator": " ",
+                                "longToWideId": "id"
+                            },
+                            "opacity": { "value": 0.4 },
+                            "tracks": [
+                                {
+                                    // "dataTransform": [
+                                    //   {"type": "filter", "field": "chr", "oneOf": ["hs1"], "not": true}
+                                    // ],
+                                    "mark": "withinLink",
+                                    "x": { "field": "p1", "type": "genomic" },
+                                    "xe": { "field": "p1_2", "type": "genomic" },
+                                    "x1": { "field": "p2", "type": "genomic" },
+                                    "x1e": { "field": "P2_2", "type": "genomic" },
+                                    "stroke": { "value": "lightgray" },
+                                    "strokeWidth": { "value": 1 }
+                                }
+                                // ,
+                                // {
+                                //   "dataTransform": [
+                                //     {"type": "filter", "field": "chr", "oneOf": ["hs1"]}
+                                //   ],
+                                //   "mark": "withinLink",
+                                //   "x": {"field": "p1", "type": "genomic"},
+                                //   "xe": {"field": "p1_2", "type": "genomic"},
+                                //   "x1": {"field": "p2", "type": "genomic"},
+                                //   "x1e": {"field": "P2_2", "type": "genomic"},
+                                //   "stroke": {
+                                //     "field": "chr_2",
+                                //     "type": "nominal",
+                                //     "range": [
+                                //       "#E79F00",
+                                //       "#029F73",
+                                //       "#0072B2",
+                                //       "#CB7AA7",
+                                //       "#D45E00",
+                                //       "#57B4E9",
+                                //       "#EFE441"
+                                //     ]
+                                //   },
+                                //   "strokeWidth": {"value": 1.5}
+                                // }
+                            ],
+                            "width": 500,
+                            "height": 100
+                        }
+                    ]
+                },
+                {
+                    "xDomain": { "chromosome": "12" },
+                    "xLinkingId": "middle",
+                    "layout": "linear",
+                    "tracks": [
+                        {
+                            "title": "Ideogram",
+                            "alignment": "overlay",
+                            "data": {
+                                "url": "https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv",
+                                "type": "csv",
+                                "chromosomeField": "Chromosome",
+                                "genomicFields": ["chromStart", "chromEnd"]
+                            },
+                            "tracks": [
+                                {
+                                    "dataTransform": [
+                                        { type: "filter", field: 'Stain', oneOf: 'acen', not: true }
+                                    ],
+                                    "mark": "rect",
+                                    "stroke": { "value": "gray" },
+                                    "strokeWidth": { "value": 0.3 },
+                                },
+                                {
+                                    "dataTransform": [
+                                        { type: "filter", field: 'Stain', oneOf: 'acen' },
+                                        { type: "filter", field: 'Name', include: ['q'] }
+                                    ],
+                                    "mark": "triangleRight",
+                                    "stroke": { "value": "gray" },
+                                    "strokeWidth": { "value": 0.3 },
+                                },
+                                {
+                                    "dataTransform": [
+                                        { type: "filter", field: 'Stain', oneOf: 'acen' },
+                                        { type: "filter", field: 'Name', include: ['p'] }
+                                    ],
+                                    "mark": "triangleLeft",
+                                    "stroke": { "value": "gray" },
+                                    "strokeWidth": { "value": 0.3 },
+                                },
+                                {
+                                    "mark": "brush",
+                                    "x": { "linkingId": "detail" }
+                                }
+                            ],
+                            "color": {
+                                "field": "Stain",
+                                "type": "nominal",
+                                "domain": [
+                                    "gneg",
+                                    "gpos25",
+                                    "gpos50",
+                                    "gpos75",
+                                    "gpos100",
+                                    "gvar",
+                                    "acen"
+                                ],
+                                //   "range": [
+                                //     "white",
+                                //     "lightgray",
+                                //     "gray",
+                                //     "gray",
+                                //     "black",
+                                //     "#7B9CC8",
+                                //     "#DC4542"
+                                //   ]
+                            },
+                            "size": { "value": 18 },
+                            "x": { "field": "chromStart", "type": "genomic" },
+                            "xe": { "field": "chromEnd", "type": "genomic" },
+                            "width": 500,
+                            "height": 50
+                        },
+                        {
+                            "alignment": "overlay",
+                            "title": "Genes",
+                            "data": {
+                                "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation",
+                                "type": "beddb",
+                                "genomicFields": [
+                                    { "index": 1, "name": "start" },
+                                    { "index": 2, "name": "end" }
+                                ],
+                                "valueFields": [
+                                    { "index": 5, "name": "strand", "type": "nominal" },
+                                    { "index": 3, "name": "name", "type": "nominal" }
+                                ],
+                                "exonIntervalFields": [
+                                    { "index": 12, "name": "start" },
+                                    { "index": 13, "name": "end" }
+                                ]
+                            },
+                            "tracks": [
+                                {
+                                    "dataTransform": [
+                                        { "type": "filter", "field": "type", "oneOf": ["gene"] },
+                                        { "type": "filter", "field": "strand", "oneOf": ["+"] }
+                                    ],
+                                    "mark": "triangleRight",
+                                    "x": { "field": "end", "type": "genomic", "linkingId": "middle" },
+                                    "size": { "value": 15 },
+                                    "opacity": { "value": 0.8 },
+                                },
+                                {
+                                    "dataTransform": [
+                                        { "type": "filter", "field": "type", "oneOf": ["gene"] }
+                                    ],
+                                    "mark": "text",
+                                    "text": { "field": "name", "type": "nominal" },
+                                    "x": { "field": "start", "type": "genomic" },
+                                    "xe": { "field": "end", "type": "genomic" },
+                                    "style": { "dy": -15 },
+                                    "opacity": { "value": 0.8 },
+                                },
+                                {
+                                    "dataTransform": [
+                                        { "type": "filter", "field": "type", "oneOf": ["gene"] },
+                                        { "type": "filter", "field": "strand", "oneOf": ["-"] }
+                                    ],
+                                    "mark": "triangleLeft",
+                                    "x": { "field": "start", "type": "genomic" },
+                                    "size": { "value": 15 },
+                                    "style": { "align": "right" },
+                                    "opacity": { "value": 0.8 },
+                                },
+                                {
+                                    "dataTransform": [
+                                        { "type": "filter", "field": "type", "oneOf": ["exon"] }
+                                    ],
+                                    "mark": "rect",
+                                    "x": { "field": "start", "type": "genomic" },
+                                    "size": { "value": 15 },
+                                    "xe": { "field": "end", "type": "genomic" },
+                                    "opacity": { "value": 0.8 },
+                                },
+                                {
+                                    "dataTransform": [
+                                        { "type": "filter", "field": "type", "oneOf": ["gene"] },
+                                        { "type": "filter", "field": "strand", "oneOf": ["+"] }
+                                    ],
+                                    "mark": "rule",
+                                    "x": { "field": "start", "type": "genomic" },
+                                    "strokeWidth": { "value": 3 },
+                                    "xe": { "field": "end", "type": "genomic" },
+                                    "opacity": { "value": 0.8 },
+                                    "style": { "linePattern": { "type": "triangleRight", "size": 5 } }
+                                },
+                                {
+                                    "dataTransform": [
+                                        { "type": "filter", "field": "type", "oneOf": ["gene"] },
+                                        { "type": "filter", "field": "strand", "oneOf": ["-"] }
+                                    ],
+                                    "mark": "rule",
+                                    "x": { "field": "start", "type": "genomic" },
+                                    "strokeWidth": { "value": 3 },
+                                    "xe": { "field": "end", "type": "genomic" },
+                                    "style": { "linePattern": { "type": "triangleLeft", "size": 5 } },
+                                    "opacity": { "value": 0.8 },
+                                },
+                                { "mark": "brush", "x": { "linkingId": "detail" } }
+                            ],
+                            "row": { "field": "strand", "type": "nominal", "domain": ["+", "-"] },
+                            "color": {
+                                "field": "strand",
+                                "type": "nominal",
+                                "domain": ["+", "-"],
+                                "legend": true
+                                //   "range": ["#7585FF", "#FF8A85"]
+                            },
+                            "visibility": [
+                                {
+                                    "operation": "less-than",
+                                    "measure": "width",
+                                    "threshold": "|xe-x|",
+                                    "transitionPadding": 10,
+                                    "target": "mark"
+                                }
+                            ],
+                            "width": 520,
+                            "height": 100
+                        },
+                        {
+                            "title": "Chromosome",
+                            "alignment": "overlay",
+                            "tracks": [
+                                { "mark": "bar" },
+                                { "mark": "brush", "x": { "linkingId": "detail" } }
+                            ],
+                            "data": {
+                                "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+                                "type": "multivec",
+                                "row": "sample",
+                                "column": "position",
+                                "value": "peak",
+                                "categories": ["sample 1", "sample 2", "sample 3", "sample 4"],
+                                "binSize": 4
+                            },
+                            "x": { "field": "start", "type": "genomic" },
+                            "xe": { "field": "end", "type": "genomic" },
+                            "y": { "field": "peak", "type": "quantitative", "grid": true },
+                            // "row": {"field": "sample", "type": "nominal"},
+                            "color": { "field": "sample", "type": "nominal", "legend": true },
+                            "width": 520,
+                            "height": 300
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "layout": "linear",
+            "xDomain": { "chromosome": "12", "interval": [46000000, 60000000] },
+            "linkingId": "detail",
+            "tracks": [
+                {
+                    title: "Sequence",
+                    "layout": "linear",
+                    "xDomain": { "chromosome": "1", "interval": [3000000, 3000010] },
+                    "alignment": "overlay",
+                    "data": {
+                        "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=sequence-multivec",
+                        "type": "multivec",
+                        "row": "base",
+                        "column": "position",
+                        "value": "count",
+                        "categories": ["A", "T", "G", "C"],
+                        "start": "start",
+                        "end": "end"
+                    },
+                    "tracks": [
+                        {
+                            "mark": "bar",
+                            "y": { "field": "count", "type": "quantitative", "axis": "none" }
+                        },
+                        {
+                            "dataTransform": [
+                                { "type": "filter", "field": "count", "oneOf": [0], "not": true }
+                            ],
+                            "mark": "text",
+                            "x": { "field": "start", "type": "genomic" },
+                            "xe": { "field": "end", "type": "genomic" },
+                            "color": { "value": "white" },
+                            "visibility": [
+                                {
+                                    "operation": "less-than",
+                                    "measure": "width",
+                                    "threshold": "|xe-x|",
+                                    "transitionPadding": 30,
+                                    "target": "mark"
+                                },
+                                {
+                                    "operation": "LT",
+                                    "measure": "zoomLevel",
+                                    "threshold": 10,
+                                    "target": "track"
+                                }
+                            ]
+                        }
+                    ],
+                    "x": { "field": "position", "type": "genomic" },
+                    "color": {
+                        "field": "base",
+                        "type": "nominal",
+                        "domain": ["A", "T", "G", "C"],
+                        "legend": true
+                    },
+                    "text": { "field": "base", "type": "nominal" },
+                    "style": {
+                        "textFontSize": 24,
+                        "textStrokeWidth": 0,
+                        "textFontWeight": "bold"
+                    },
+                    "width": 800,
+                    "height": 100
+                },
+                {
+                    "title": "Detail View",
+                    "data": {
+                        "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+                        "type": "multivec",
+                        "row": "sample",
+                        "column": "position",
+                        "value": "peak",
+                        "categories": ["sample 1", "sample 2", "sample 3", "sample 4"],
+                        "binSize": 4
+                    },
+                    "alignment": "overlay",
+                    "tracks": [
+                        { "mark": "point" },
+                        { "mark": "line" }
+                    ],
+                    "x": { "field": "position", "type": "genomic" },
+                    // "xe": { "field": "end", "type": "genomic", "axis": "top" },
+                    "y": { "field": "peak", "type": "quantitative", "grid": true },
+                    "row": { "field": "sample", "type": "nominal" },
+                    "color": { "field": "sample", "type": "nominal", "legend": true },
+                    "width": 1104,
+                    "height": 200
+                }
+            ]
+        }
+    ]
+}

--- a/demo/example-2.js
+++ b/demo/example-2.js
@@ -1,0 +1,268 @@
+example2 = {
+    "title": "Gosling Theme",
+    "subtitle": "Using the gosling themes, you can easily apply styling to gosling visualizations",
+    "layout": "linear",
+    "arrangement": "vertical",
+    "centerRadius": 0.8,
+    "xDomain": { "chromosome": "1", "interval": [1, 3000500] },
+    "views": [
+        {
+            "id": "view-1",
+            "tracks": [
+                {
+                    "data": {
+                        "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+                        "type": "multivec",
+                        "row": "sample",
+                        "column": "position",
+                        "value": "peak",
+                        "categories": ["sample 1", "sample 2", "sample 3", "sample 4"],
+                        "binSize": 4
+                    },
+                    "mark": "rect",
+                    "x": { "field": "start", "type": "genomic", "axis": "top" },
+                    "xe": { "field": "end", "type": "genomic" },
+                    "row": { "field": "sample", "type": "nominal", "legend": true },
+                    "color": { "field": "peak", "type": "quantitative", "legend": true },
+                    "tooltip": [
+                        { "field": "start", "type": "genomic", "alt": "Start Position" },
+                        { "field": "end", "type": "genomic", "alt": "End Position" },
+                        {
+                            "field": "peak",
+                            "type": "quantitative",
+                            "alt": "Value",
+                            "format": ".2"
+                        },
+                        { "field": "sample", "type": "nominal", "alt": "Sample" }
+                    ],
+                    "width": 600,
+                    "height": 130
+                }
+            ]
+        },
+        {
+            "tracks": [
+                {
+                    "data": {
+                        "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+                        "type": "multivec",
+                        "row": "sample",
+                        "column": "position",
+                        "value": "peak",
+                        "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
+                    },
+                    "mark": "bar",
+                    "x": { "field": "position", "type": "genomic", "axis": "top" },
+                    "y": { "field": "peak", "type": "quantitative" },
+                    "row": { "field": "sample", "type": "nominal" },
+                    "color": { "field": "sample", "type": "nominal", "legend": true },
+                    "tooltip": [
+                        { "field": "position", "type": "genomic", "alt": "Position" },
+                        {
+                            "field": "peak",
+                            "type": "quantitative",
+                            "alt": "Value",
+                            "format": ".2"
+                        },
+                        { "field": "sample", "type": "nominal", "alt": "Sample" }
+                    ],
+                    "width": 600,
+                    "height": 130
+                }
+            ]
+        },
+        {
+            "tracks": [
+                {
+                    "data": {
+                        "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+                        "type": "multivec",
+                        "row": "sample",
+                        "column": "position",
+                        "value": "peak",
+                        "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
+                    },
+                    "mark": "bar",
+                    "x": { "field": "position", "type": "genomic", "axis": "top" },
+                    "y": { "field": "peak", "type": "quantitative", "grid": true },
+                    "color": { "field": "sample", "type": "nominal", "legend": true },
+                    "tooltip": [
+                        { "field": "position", "type": "genomic", "alt": "Position" },
+                        {
+                            "field": "peak",
+                            "type": "quantitative",
+                            "alt": "Value",
+                            "format": ".2"
+                        },
+                        { "field": "sample", "type": "nominal", "alt": "Sample" }
+                    ],
+                    "width": 600,
+                    "height": 130
+                }
+            ]
+        },
+        {
+            "alignment": "overlay",
+            "data": {
+                "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+                "type": "multivec",
+                "row": "sample",
+                "column": "position",
+                "value": "peak",
+                "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
+            },
+            "x": { "field": "position", "type": "genomic", "axis": "top" },
+            "y": { "field": "peak", "type": "quantitative" },
+            "row": { "field": "sample", "type": "nominal" },
+            "color": { "field": "sample", "type": "nominal", "legend": true },
+            "tracks": [
+                { "mark": "line" },
+                {
+                    "mark": "point",
+                    "size": { "field": "peak", "type": "quantitative", "range": [0, 2] }
+                }
+            ],
+            "tooltip": [
+                { "field": "position", "type": "genomic", "alt": "Position" },
+                {
+                    "field": "peak",
+                    "type": "quantitative",
+                    "alt": "Value",
+                    "format": ".2"
+                },
+                { "field": "sample", "type": "nominal", "alt": "Sample" }
+            ],
+            "width": 600,
+            "height": 130
+        },
+        {
+            "tracks": [
+                {
+                    "data": {
+                        "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+                        "type": "multivec",
+                        "row": "sample",
+                        "column": "position",
+                        "value": "peak",
+                        "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
+                    },
+                    "mark": "point",
+                    "x": { "field": "position", "type": "genomic", "axis": "top" },
+                    "y": { "field": "peak", "type": "quantitative" },
+                    "row": { "field": "sample", "type": "nominal" },
+                    "size": { "field": "peak", "type": "quantitative" },
+                    "color": { "field": "sample", "type": "nominal", "legend": true },
+                    "opacity": { "value": 0.5 },
+                    "tooltip": [
+                        { "field": "position", "type": "genomic", "alt": "Position" },
+                        {
+                            "field": "peak",
+                            "type": "quantitative",
+                            "alt": "Value",
+                            "format": ".2"
+                        },
+                        { "field": "sample", "type": "nominal", "alt": "Sample" }
+                    ],
+                    "width": 600,
+                    "height": 130
+                }
+            ]
+        },
+        {
+            "tracks": [
+                {
+                    "data": {
+                        "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+                        "type": "multivec",
+                        "row": "sample",
+                        "column": "position",
+                        "value": "peak",
+                        "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
+                    },
+                    "mark": "point",
+                    "x": { "field": "position", "type": "genomic", "axis": "top" },
+                    "y": { "field": "peak", "type": "quantitative", "grid": true },
+                    "size": { "field": "peak", "type": "quantitative" },
+                    "color": { "field": "sample", "type": "nominal", "legend": true },
+                    "opacity": { "value": 0.5 },
+                    "tooltip": [
+                        { "field": "position", "type": "genomic", "alt": "Position" },
+                        {
+                            "field": "peak",
+                            "type": "quantitative",
+                            "alt": "Value",
+                            "format": ".2"
+                        },
+                        { "field": "sample", "type": "nominal", "alt": "Sample" }
+                    ],
+                    "width": 600,
+                    "height": 130
+                }
+            ]
+        },
+        {
+            "tracks": [
+                {
+                    "data": {
+                        "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+                        "type": "multivec",
+                        "row": "sample",
+                        "column": "position",
+                        "value": "peak",
+                        "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
+                    },
+                    "mark": "area",
+                    "x": { "field": "position", "type": "genomic", "axis": "top" },
+                    "y": { "field": "peak", "type": "quantitative" },
+                    "row": { "field": "sample", "type": "nominal" },
+                    "color": { "field": "sample", "type": "nominal", "legend": true },
+                    "stroke": { "value": "white" },
+                    "strokeWidth": { "value": 0.5 },
+                    "tooltip": [
+                        { "field": "position", "type": "genomic", "alt": "Position" },
+                        {
+                            "field": "peak",
+                            "type": "quantitative",
+                            "alt": "Value",
+                            "format": ".2"
+                        },
+                        { "field": "sample", "type": "nominal", "alt": "Sample" }
+                    ],
+                    "width": 600,
+                    "height": 130
+                }
+            ]
+        },
+        {
+            "tracks": [
+                {
+                    "data": {
+                        "url": "https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt",
+                        "type": "csv",
+                        "chromosomeField": "c2",
+                        "genomicFields": ["s1", "e1", "s2", "e2"]
+                    },
+                    "mark": "withinLink",
+                    "x": {
+                        "field": "s1",
+                        "type": "genomic",
+                        "domain": { "chromosome": "1", "interval": [103900000, 104100000] }
+                    },
+                    "xe": { "field": "e1", "type": "genomic" },
+                    "x1": {
+                        "field": "s2",
+                        "type": "genomic",
+                        "domain": { "chromosome": "1" }
+                    },
+                    "x1e": { "field": "e2", "type": "genomic" },
+                    "color": { "field": "s1", "type": "nominal" },
+                    "stroke": { "value": "black" },
+                    "strokeWidth": { "value": 0.5 },
+                    "opacity": { "value": 0.2 },
+                    "width": 600,
+                    "height": 130
+                }
+            ]
+        }
+    ]
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,14 +3,25 @@
 
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="lightgray" />
+    <!-- <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="lightgray" /> -->
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/higlass@1.11.3/dist/hglib.css">
 </head>
 
 <body
     style="font-family: 'Roboto Condensed', Roboto, -apple-system, BlinkMacSystemFont, 'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;">
-    <h1>Gosling Theme</h1>
+    <script crossorigin type="text/javascript" src="example-1.js"></script>
+    <script crossorigin type="text/javascript" src="example-2.js"></script>
+    <script crossorigin type="text/javascript" src="https://unpkg.com/react@16/umd/react.development.js"></script>
+    <script crossorigin type="text/javascript"
+        src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+    <script crossorigin type="text/javascript" src="https://unpkg.com/pixi.js@5/dist/pixi.js"></script>
+    <script crossorigin type="text/javascript" src="https://unpkg.com/gosling.js@0.8.9/dist/gosling.js"></script>
+    <script crossorigin type="text/javascript" src="dist/gosling-theme.js"></script>
+
+    <!-- UI Components -->
+    <b>Select Theme: </b>
     <select name="demo" onChange="demo(this)">
         <option value='light'>light</option>
         <option value='dark'>dark</option>
@@ -25,13 +36,7 @@
         <option value='washu'>washu</option>
         <!-- Add More ... -->
     </select>
-    <div id="root" />
-    <script crossorigin type="text/javascript" src="https://unpkg.com/react@16/umd/react.development.js"></script>
-    <script crossorigin type="text/javascript"
-        src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
-    <script crossorigin type="text/javascript" src="https://unpkg.com/pixi.js@5/dist/pixi.js"></script>
-    <script crossorigin type="text/javascript" src="https://unpkg.com/gosling.js@0.8.7/dist/gosling.js"></script>
-    <script crossorigin type="text/javascript" src="dist/gosling-theme.js"></script>
+    <div id="root" style="margin-top: 20px" />
 </body>
 <script>
     console.log(`Gosling v${gosling.version}`);
@@ -41,6 +46,7 @@
     Object.keys(goslingTheme.Themes)
 
     let selectedDemo = 'light';
+    const exampleSpec = [example1, example2][0]; // we could change this to show different example
     updateDemo();
     
     function demo(event) {
@@ -51,280 +57,17 @@
     }
 
     function updateDemo() {
+        console.log(selectedDemo, goslingTheme.Themes[selectedDemo]);
         gosling.embed(
             document.getElementById('root'),
+            JSON.parse(JSON.stringify(exampleSpec)),
             {
-                // "title": "Gosling Theme",
-                // "subtitle": "This example shows gosling visualization with theme",
-                "layout": "linear",
-                "arrangement": "vertical",
-                "centerRadius": 0.8,
-                "xDomain": { "chromosome": "1", "interval": [1, 3000500] },
-                "views": [
-                    {
-                        "id": "view-1",
-                        "tracks": [
-                            {
-                                "data": {
-                                    "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
-                                    "type": "multivec",
-                                    "row": "sample",
-                                    "column": "position",
-                                    "value": "peak",
-                                    "categories": ["sample 1", "sample 2", "sample 3", "sample 4"],
-                                    "binSize": 4
-                                },
-                                "mark": "rect",
-                                "x": { "field": "start", "type": "genomic", "axis": "top" },
-                                "xe": { "field": "end", "type": "genomic" },
-                                "row": { "field": "sample", "type": "nominal", "legend": true },
-                                "color": { "field": "peak", "type": "quantitative", "legend": true },
-                                "tooltip": [
-                                    { "field": "start", "type": "genomic", "alt": "Start Position" },
-                                    { "field": "end", "type": "genomic", "alt": "End Position" },
-                                    {
-                                        "field": "peak",
-                                        "type": "quantitative",
-                                        "alt": "Value",
-                                        "format": ".2"
-                                    },
-                                    { "field": "sample", "type": "nominal", "alt": "Sample" }
-                                ],
-                                "width": 600,
-                                "height": 130
-                            }
-                        ]
-                    },
-                    {
-                        "tracks": [
-                            {
-                                "data": {
-                                    "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
-                                    "type": "multivec",
-                                    "row": "sample",
-                                    "column": "position",
-                                    "value": "peak",
-                                    "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
-                                },
-                                "mark": "bar",
-                                "x": { "field": "position", "type": "genomic", "axis": "top" },
-                                "y": { "field": "peak", "type": "quantitative" },
-                                "row": { "field": "sample", "type": "nominal" },
-                                "color": { "field": "sample", "type": "nominal", "legend": true },
-                                "tooltip": [
-                                    { "field": "position", "type": "genomic", "alt": "Position" },
-                                    {
-                                        "field": "peak",
-                                        "type": "quantitative",
-                                        "alt": "Value",
-                                        "format": ".2"
-                                    },
-                                    { "field": "sample", "type": "nominal", "alt": "Sample" }
-                                ],
-                                "width": 600,
-                                "height": 130
-                            }
-                        ]
-                    },
-                    {
-                        "tracks": [
-                            {
-                                "data": {
-                                    "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
-                                    "type": "multivec",
-                                    "row": "sample",
-                                    "column": "position",
-                                    "value": "peak",
-                                    "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
-                                },
-                                "mark": "bar",
-                                "x": { "field": "position", "type": "genomic", "axis": "top" },
-                                "y": { "field": "peak", "type": "quantitative", "grid": true },
-                                "color": { "field": "sample", "type": "nominal", "legend": true },
-                                "tooltip": [
-                                    { "field": "position", "type": "genomic", "alt": "Position" },
-                                    {
-                                        "field": "peak",
-                                        "type": "quantitative",
-                                        "alt": "Value",
-                                        "format": ".2"
-                                    },
-                                    { "field": "sample", "type": "nominal", "alt": "Sample" }
-                                ],
-                                "width": 600,
-                                "height": 130
-                            }
-                        ]
-                    },
-                    {
-                        "alignment": "overlay",
-                        "data": {
-                            "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
-                            "type": "multivec",
-                            "row": "sample",
-                            "column": "position",
-                            "value": "peak",
-                            "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
-                        },
-                        "x": { "field": "position", "type": "genomic", "axis": "top" },
-                        "y": { "field": "peak", "type": "quantitative" },
-                        "row": { "field": "sample", "type": "nominal" },
-                        "color": { "field": "sample", "type": "nominal", "legend": true },
-                        "tracks": [
-                            { "mark": "line" },
-                            {
-                                "mark": "point",
-                                "size": { "field": "peak", "type": "quantitative", "range": [0, 2] }
-                            }
-                        ],
-                        "tooltip": [
-                            { "field": "position", "type": "genomic", "alt": "Position" },
-                            {
-                                "field": "peak",
-                                "type": "quantitative",
-                                "alt": "Value",
-                                "format": ".2"
-                            },
-                            { "field": "sample", "type": "nominal", "alt": "Sample" }
-                        ],
-                        "width": 600,
-                        "height": 130
-                    },
-                    {
-                        "tracks": [
-                            {
-                                "data": {
-                                    "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
-                                    "type": "multivec",
-                                    "row": "sample",
-                                    "column": "position",
-                                    "value": "peak",
-                                    "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
-                                },
-                                "mark": "point",
-                                "x": { "field": "position", "type": "genomic", "axis": "top" },
-                                "y": { "field": "peak", "type": "quantitative" },
-                                "row": { "field": "sample", "type": "nominal" },
-                                "size": { "field": "peak", "type": "quantitative" },
-                                "color": { "field": "sample", "type": "nominal", "legend": true },
-                                "opacity": { "value": 0.5 },
-                                "tooltip": [
-                                    { "field": "position", "type": "genomic", "alt": "Position" },
-                                    {
-                                        "field": "peak",
-                                        "type": "quantitative",
-                                        "alt": "Value",
-                                        "format": ".2"
-                                    },
-                                    { "field": "sample", "type": "nominal", "alt": "Sample" }
-                                ],
-                                "width": 600,
-                                "height": 130
-                            }
-                        ]
-                    },
-                    {
-                        "tracks": [
-                            {
-                                "data": {
-                                    "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
-                                    "type": "multivec",
-                                    "row": "sample",
-                                    "column": "position",
-                                    "value": "peak",
-                                    "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
-                                },
-                                "mark": "point",
-                                "x": { "field": "position", "type": "genomic", "axis": "top" },
-                                "y": { "field": "peak", "type": "quantitative", "grid": true },
-                                "size": { "field": "peak", "type": "quantitative" },
-                                "color": { "field": "sample", "type": "nominal", "legend": true },
-                                "opacity": { "value": 0.5 },
-                                "tooltip": [
-                                    { "field": "position", "type": "genomic", "alt": "Position" },
-                                    {
-                                        "field": "peak",
-                                        "type": "quantitative",
-                                        "alt": "Value",
-                                        "format": ".2"
-                                    },
-                                    { "field": "sample", "type": "nominal", "alt": "Sample" }
-                                ],
-                                "width": 600,
-                                "height": 130
-                            }
-                        ]
-                    },
-                    {
-                        "tracks": [
-                            {
-                                "data": {
-                                    "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
-                                    "type": "multivec",
-                                    "row": "sample",
-                                    "column": "position",
-                                    "value": "peak",
-                                    "categories": ["sample 1", "sample 2", "sample 3", "sample 4"]
-                                },
-                                "mark": "area",
-                                "x": { "field": "position", "type": "genomic", "axis": "top" },
-                                "y": { "field": "peak", "type": "quantitative" },
-                                "row": { "field": "sample", "type": "nominal" },
-                                "color": { "field": "sample", "type": "nominal", "legend": true },
-                                "stroke": { "value": "white" },
-                                "strokeWidth": { "value": 0.5 },
-                                "tooltip": [
-                                    { "field": "position", "type": "genomic", "alt": "Position" },
-                                    {
-                                        "field": "peak",
-                                        "type": "quantitative",
-                                        "alt": "Value",
-                                        "format": ".2"
-                                    },
-                                    { "field": "sample", "type": "nominal", "alt": "Sample" }
-                                ],
-                                "width": 600,
-                                "height": 130
-                            }
-                        ]
-                    },
-                    {
-                        "tracks": [
-                            {
-                                "data": {
-                                    "url": "https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt",
-                                    "type": "csv",
-                                    "chromosomeField": "c2",
-                                    "genomicFields": ["s1", "e1", "s2", "e2"]
-                                },
-                                "mark": "withinLink",
-                                "x": {
-                                    "field": "s1",
-                                    "type": "genomic",
-                                    "domain": { "chromosome": "1", "interval": [103900000, 104100000] }
-                                },
-                                "xe": { "field": "e1", "type": "genomic" },
-                                "x1": {
-                                    "field": "s2",
-                                    "type": "genomic",
-                                    "domain": { "chromosome": "1" }
-                                },
-                                "x1e": { "field": "e2", "type": "genomic" },
-                                "color": { "field": "s1", "type": "nominal" },
-                                "stroke": { "value": "black" },
-                                "strokeWidth": { "value": 0.5 },
-                                "opacity": { "value": 0.2 },
-                                "width": 600,
-                                "height": 130
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
+                // margin: 30,
+                // padding: 0,
+                // border: '1px dashed gray',
                 theme: goslingTheme.Themes[selectedDemo]
             }
-        );
+        );        
     }
 </script>
 

--- a/src/light.ts
+++ b/src/light.ts
@@ -16,21 +16,39 @@ export const light = {
     root: {
         background: 'white',
         titleColor: 'black',
+        titleBackgroundColor: 'transparent',
+        titleFontSize: 18,
+        titleFontFamily: 'Arial',
+        titleAlign: 'left',
+        titleFontWeight: 'bold',
         subtitleColor: 'gray',
+        subtitleBackgroundColor: 'transparent',
+        subtitleFontSize: 16,
+        subtitleFontFamily: 'Arial',
+        subtitleFontWeight: 'normal',
+        subtitleAlign: 'left',
         mousePositionColor: '#000000'
     },
 
     track: {
+        background: 'transparent',
+        alternatingBackground: 'transparent',
         titleColor: 'black',
         titleBackground: 'white',
+        titleFontSize: 24,
+        titleAlign: 'left',
         outline: 'black',
         outlineWidth: 1
     },
 
     legend: {
+        position: 'top',
         background: 'white',
         backgroundOpacity: 0.7,
         labelColor: 'black',
+        labelFontSize: 12,
+        labelFontWeight: 'normal',
+        labelFontFamily: 'Arial',
         backgroundStroke: '#DBDBDB',
         tickColor: 'black'
     },
@@ -38,9 +56,14 @@ export const light = {
     axis: {
         tickColor: 'black',
         labelColor: 'black',
+        labelFontSize: 12,
+        labelFontWeight: 'normal',
+        labelFontFamily: 'Arial',
         baselineColor: 'black',
         gridColor: '#E3E3E3',
-        gridStrokeWidth: 1
+        gridStrokeWidth: 1,
+        gridStrokeType: 'solid',
+        gridStrokeDash: [4, 4]
     },
 
     markCommon: {


### PR DESCRIPTION
This PR update the two major things:

1. Show a more proper demo example. In this example, we show both the circular and linear visualizations, interactive brushes, multiple marks (e.g., line, point, bar, arcs), rows (for alternating background), grids, legends, and some conventional visualizations like ideograms, gene annotations, and a sequence track.

![Screen Shot 2021-07-19 at 9 48 00 PM](https://user-images.githubusercontent.com/9922882/126250053-dfc621a3-a5f5-4544-8ff4-bc6ec2a6fd40.png)

2. Use the latest Gosling.js which supports more theme components. Please refer to [this PR](https://github.com/gosling-lang/gosling.js/pull/436) to find the complete list of additionally supported properties.

3. For @cjrosa23's convenience, I've updated the `light.ts` file to additionally specify all the recently added properties. This file can be used as a reference to update all other theme definition files.

For any further instructions (e.g., using additional font families in your browser), please refer to `README.md`.
