### PR TITLE
chore: cleanup package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "start": "vite",
     "build": "vite build && tsc"
   },
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "gh-pages": "^3.2.3",
     "gosling.js": "0.9.1",


### PR DESCRIPTION
The `v0.9` is missing the esm "module" export as well as the "types":

```
node_modules/gosling-theme
├── LICENSE.md
├── README.md
├── demo
│   ├── example-1.js
│   ├── example-2.js
│   └── index.html
├── dist
│   └── gosling-theme.umd.js
├── package.json
├── src
│   ├── dark.ts
│   ├── ensembl.ts
│   ├── excel.ts
│   ├── ggplot.ts
│   ├── google.ts
│   ├── igv.ts
│   ├── index.ts
│   ├── jbrowse.ts
│   ├── light.ts
│   ├── test.ts
│   ├── ucsc.ts
│   ├── warm.ts
│   └── washu.ts
├── tsconfig.json
└── vite.config.js
```

so module resolution fails. This PR restricts the NPM package to only include `dist`, but I'd request that the package is re-published. `dist` should include:

```
├── gosling-theme.es.js
├── gosling-theme.es.js.map
├── gosling-theme.umd.js
├── gosling-theme.umd.js.map
└── types
    ├── dark.d.ts
    ├── ensembl.d.ts
    ├── excel.d.ts
    ├── ggplot.d.ts
    ├── google.d.ts
    ├── igv.d.ts
    ├── index.d.ts
    ├── jbrowse.d.ts
    ├── light.d.ts
    ├── test.d.ts
    ├── ucsc.d.ts
    ├── warm.d.ts
    └── washu.d.ts
```